### PR TITLE
Docs/#53: swagger api 문서 작성

### DIFF
--- a/srcs/controllers/controller.getOneUserComments.ts
+++ b/srcs/controllers/controller.getOneUserComments.ts
@@ -5,11 +5,11 @@ const getOneUserComments: RequestHandler = async (req, res) => {
     try {
         const userId: string = req.params.id;
 
-        const comments = await findOneUserComment(userId);
+        const comment = await findOneUserComment(userId);
 
         return res.status(200).json({
             success: true,
-            data: { comments },
+            data: { comment },
         });
     } catch (error: any) {
         res.status(400).json({

--- a/srcs/controllers/controller.getOneUserPosts.ts
+++ b/srcs/controllers/controller.getOneUserPosts.ts
@@ -5,11 +5,11 @@ const getOneUserPosts: RequestHandler = async (req, res) => {
     try {
         const userId: string = req.params.id;
 
-        const posts = await findAllPostsByUser(userId);
+        const post = await findAllPostsByUser(userId);
 
         return res.status(200).json({
             success: true,
-            data: { posts },
+            data: { post },
         });
     } catch (error: any) {
         res.status(400).json({

--- a/srcs/repository/repository.comment.ts
+++ b/srcs/repository/repository.comment.ts
@@ -3,9 +3,11 @@ import { Post, Comment, User } from '../entity/index';
 const findOneUserComment: (id: string) => Promise<Comment[]> = async (id) => {
     const userId = parseInt(id);
     if (isNaN(userId)) throw Error('Please enter a numeric character for the id value.');
+    const targetUser = await User.findOne({ id: userId });
+    if (targetUser === undefined) throw Error(`This user_id does not exist.`);
 
     const result = await Comment.createQueryBuilder('comment')
-        .select(['user_id', 'P.post_id', 'id as comment_id', 'content', 'P.title'])
+        .select(['user_id', 'P.post_id', 'id as comment_id', 'P.title', 'content'])
         .leftJoin(
             (qb) =>
                 qb.from(Post, 'post').select(['title', 'created_at']).addSelect('id', 'post_id'),

--- a/srcs/repository/repository.policy.ts
+++ b/srcs/repository/repository.policy.ts
@@ -140,6 +140,8 @@ const likeOrDislikePolicy: (userId: number, policyId: number) => Promise<void> =
 const findOneUserLikePolicy: (id: string) => Promise<Policy[]> = async (id) => {
     const userId = parseInt(id);
     if (isNaN(userId)) throw Error('Please enter a numeric character for the id value.');
+    const targetUser = await User.findOne({ id: userId });
+    if (targetUser === undefined) throw Error(`This user_id does not exist.`);
 
     const result = await User.createQueryBuilder('user')
         .select([

--- a/srcs/repository/repository.posts.ts
+++ b/srcs/repository/repository.posts.ts
@@ -114,6 +114,8 @@ const findCommentsByPostId: (postId: string) => Promise<Comment[] | undefined> =
 const findAllPostsByUser: (id: string) => Promise<Post[]> = async (id) => {
     const userId = parseInt(id);
     if (isNaN(userId)) throw Error('id is not number');
+    const targetUser = await User.findOne({ id: userId });
+    if (targetUser === undefined) throw Error(`This user_id does not exist.`);
 
     const result = await User.createQueryBuilder('U')
         .select(['id as user_id', 'post_id', 'nickname', 'P.category', 'title', 'content', 'C.cnt'])

--- a/srcs/repository/repository.user.ts
+++ b/srcs/repository/repository.user.ts
@@ -72,6 +72,8 @@ const updateOneUserFilterById: (user: tUser) => Promise<tUser | undefined> = asy
         .execute();
 
     const targetUser = await User.findOne({ id: user.id });
+    if (targetUser === undefined) throw Error(`This user_id does not exist.`);
+
     return targetUser;
 };
 

--- a/srcs/repository/repository.user.ts
+++ b/srcs/repository/repository.user.ts
@@ -35,6 +35,8 @@ const updateOneUserNicknameById: (
     nickname?: string
 ) => Promise<tUser | undefined> = async (id, nickname) => {
     const numId = parseInt(id);
+    if (isNaN(numId)) throw Error('Please enter a numeric character for the id value.');
+
     await getConnection()
         .createQueryBuilder()
         .update(User)
@@ -45,6 +47,7 @@ const updateOneUserNicknameById: (
         .execute();
 
     const targetUser = await User.findOne({ id: numId });
+    if (targetUser === undefined) throw Error(`This user_id does not exist.`);
     return targetUser;
 };
 

--- a/srcs/swagger/controller/auth.ts
+++ b/srcs/swagger/controller/auth.ts
@@ -43,7 +43,7 @@
  *                                      $ref: "#/components/schemas/UserToken"
  *              400:
  *                  description: |
- *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                    -오류 예시</br>
  *                    - header에 access_token or refresh_token을 넣지 않고 요청했을 경우 <br>
  *                  content:
@@ -66,7 +66,7 @@
  *                                  location: headers
  *              401:
  *                  description: |
- *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                    -오류 예시</br>
  *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
  *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
@@ -129,7 +129,7 @@
  *                                      $ref: "#/components/schemas/UserToken"
  *              400:
  *                  description: |
- *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                    -오류 예시</br>
  *                    - header에 access_tokne or refresh_token을 넣지 않고 요청했을 경우 <br>
  *                  content:
@@ -152,7 +152,7 @@
  *                                  location: headers
  *              401:
  *                  description: |
- *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                    -오류 예시</br>
  *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
  *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
@@ -188,7 +188,7 @@
  *              - in: header
  *                name: access_token
  *                required: true
- *                description: kakao api에서 발급받은 access_token
+ *                description: naver api에서 발급받은 access_token
  *                schema:
  *                    type: string
  *          responses:
@@ -208,7 +208,7 @@
  *                                      type: number
  *              400:
  *                  description: |
- *                    오류가 발생해 spoon feed에 naver 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    오류가 발생해 spoon feed에 naver 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                    -오류 예시</br>
  *                    - header에 access_token 넣지 않고 요청했을 경우 <br>
  *                  content:
@@ -231,9 +231,160 @@
  *                                  location: headers
  *              401:
  *                  description: |
- *                    오류가 발생해 spoon feed에 naver 계정으로 성공적으로 소셜 로그아웃하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    인증 오류가 발생해 spoon feed에 naver 계정으로 성공적으로 소셜 로그아웃하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                    -오류 예시</br>
  *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                success: false
+ *                                error:
+ *                                  error: invalid_grant
+ *                                  error_description: expired_or_invalid_refresh_token
+ *                                  error_code: KOE322
+ */
+
+/**
+ * @swagger
+ * paths:
+ *  /logout/kakao:
+ *      get:
+ *          description: spoon feed에 kakao 계정으로 로그아웃 합니다.
+ *          tags: [Auth]
+ *          parameters:
+ *              - in: header
+ *                name: access_token
+ *                required: true
+ *                description: kakao api에서 발급받은 access_token
+ *                schema:
+ *                    type: string
+ *          responses:
+ *              200:
+ *                  description: spoon feed에 kakao 계정으로 성공적으로 로그아웃하였을 경우 다음 결과가 반환됩니다. <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                data:
+ *                                  type: object
+ *                                  properties:
+ *                                    id:
+ *                                      type: number
+ *              400:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                    -오류 예시</br>
+ *                    - header에 access_token 넣지 않고 요청했을 경우 <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                errors:
+ *                                  msg: Invalid value
+ *                                  param: access_token
+ *                                  location: headers
+ *              401:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그아웃하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                    -오류 예시</br>
+ *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                success: false
+ *                                error:
+ *                                  error: invalid_grant
+ *                                  error_description: expired_or_invalid_refresh_token
+ *                                  error_code: KOE322
+ */
+
+/**
+ * @swagger
+ * paths:
+ *  /token:
+ *      get:
+ *          description: request header에 refresh_token값을 담아 응답을 받고 갱신된 access_token과 refresh_token을 응답의 header으로 받습니다.
+ *          tags: [Auth]
+ *          parameters:
+ *              - in: header
+ *                name: refresh_token
+ *                required: true
+ *                description: 발급받아 저장해뒀던 refresh_token
+ *                schema:
+ *                    type: string
+ *          responses:
+ *              200:
+ *                  description: access_token과 refresh_token을 성공적으로 갱신하였을 경우 다음 결과가 반환됩니다. <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *              400:
+ *                  description: |
+ *                    오류가 발생해 access_token과 refresh_token을 성공적으로 갱신하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                    -오류 예시</br>
+ *                    - header에 refresh_token 넣지 않고 요청했을 경우 <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                errors:
+ *                                  msg: Invalid value
+ *                                  param: refresh_token
+ *                                  location: headers
+ *              401:
+ *                  description: |
+ *                    인증 오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그아웃하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                    -오류 예시</br>
+ *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
  *                  content:
  *                      application/json:
  *                          schema:

--- a/srcs/swagger/controller/auth.ts
+++ b/srcs/swagger/controller/auth.ts
@@ -45,7 +45,7 @@
  *                  description: |
  *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
  *                    -오류 예시</br>
- *                    - header에 access_tokne or refresh_token을 넣지 않고 요청했을 경우 <br>
+ *                    - header에 access_token or refresh_token을 넣지 않고 요청했을 경우 <br>
  *                  content:
  *                      application/json:
  *                          schema:
@@ -152,10 +152,88 @@
  *                                  location: headers
  *              401:
  *                  description: |
- *                    오류가 발생해 spoon feed에 네kakao이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
  *                    -오류 예시</br>
  *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
  *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                success: false
+ *                                error:
+ *                                  error: invalid_grant
+ *                                  error_description: expired_or_invalid_refresh_token
+ *                                  error_code: KOE322
+ */
+
+/**
+ * @swagger
+ * paths:
+ *  /logout/naver:
+ *      get:
+ *          description: spoon feed에 네이버 계정으로 로그아웃 합니다.
+ *          tags: [Auth]
+ *          parameters:
+ *              - in: header
+ *                name: access_token
+ *                required: true
+ *                description: kakao api에서 발급받은 access_token
+ *                schema:
+ *                    type: string
+ *          responses:
+ *              200:
+ *                  description: spoon feed에 naver 계정으로 성공적으로 로그아웃하였을 경우 다음 결과가 반환됩니다. <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                data:
+ *                                  type: object
+ *                                  properties:
+ *                                    id:
+ *                                      type: number
+ *              400:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 naver 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    -오류 예시</br>
+ *                    - header에 access_token 넣지 않고 요청했을 경우 <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                errors:
+ *                                  msg: Invalid value
+ *                                  param: access_token
+ *                                  location: headers
+ *              401:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 naver 계정으로 성공적으로 소셜 로그아웃하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    -오류 예시</br>
+ *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
  *                  content:
  *                      application/json:
  *                          schema:

--- a/srcs/swagger/controller/auth.ts
+++ b/srcs/swagger/controller/auth.ts
@@ -45,6 +45,29 @@
  *                  description: |
  *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
  *                    -오류 예시</br>
+ *                    - header에 access_tokne or refresh_token을 넣지 않고 요청했을 경우 <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                errors:
+ *                                  msg: Invalid value
+ *                                  param: refresh_token
+ *                                  location: headers
+ *              401:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    -오류 예시</br>
  *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
  *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
  *                  content:
@@ -66,27 +89,4 @@
  *                                  error: invalid_grant
  *                                  error_description: expired_or_invalid_refresh_token
  *                                  error_code: KOE322
- *              401:
- *                  description: Authentication Error |
- *                    user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
- *                    - 오류 예시</br>
- *                    - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
- *                  content:
- *                      application/json:
- *                          schema:
- *                              type: object
- *                              properties:
- *                                success:
- *                                  type: boolean
- *                                error:
- *                                  properties:
- *                                   code:
- *                                     type: string
- *                                   message:
- *                                     type: string
- *                              example:
- *                                success: false
- *                                error:
- *                                  code: -401
- *                                  message: this access token does not exist
  */

--- a/srcs/swagger/controller/auth.ts
+++ b/srcs/swagger/controller/auth.ts
@@ -90,3 +90,89 @@
  *                                  error_description: expired_or_invalid_refresh_token
  *                                  error_code: KOE322
  */
+
+/**
+ * @swagger
+ * paths:
+ *  /login/kakao:
+ *      get:
+ *          description: spoon feed에 카카오 계정으로 소셜 로그인을 합니다.
+ *          tags: [Auth]
+ *          parameters:
+ *              - in: header
+ *                name: access_token
+ *                required: true
+ *                description: kakao api에서 발급받은 access_token
+ *                schema:
+ *                    type: string
+ *              - in: header
+ *                name: refresh_token
+ *                required: true
+ *                description: kakao api에서 발급받은 refresh_token
+ *                schema:
+ *                    type: string
+ *          responses:
+ *              200:
+ *                  description: spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하였을 경우 다음 결과가 반환됩니다. <br>
+ *                               응답의 header에 access_token과 refresh_token, platform을 담아 반환합니다.</br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                data:
+ *                                  type: object
+ *                                  properties:
+ *                                    user:
+ *                                      $ref: "#/components/schemas/UserToken"
+ *              400:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    -오류 예시</br>
+ *                    - header에 access_tokne or refresh_token을 넣지 않고 요청했을 경우 <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                errors:
+ *                                  msg: Invalid value
+ *                                  param: refresh_token
+ *                                  location: headers
+ *              401:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 네kakao이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    -오류 예시</br>
+ *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
+ *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                success: false
+ *                                error:
+ *                                  error: invalid_grant
+ *                                  error_description: expired_or_invalid_refresh_token
+ *                                  error_code: KOE322
+ */

--- a/srcs/swagger/controller/auth.ts
+++ b/srcs/swagger/controller/auth.ts
@@ -1,0 +1,92 @@
+/**
+ * @swagger
+ * tags:
+ *   name: Auth
+ *   description: 로그인, 인증
+ */
+
+/**
+ * @swagger
+ * paths:
+ *  /login/naver:
+ *      get:
+ *          description: spoon feed에 네이버 계정으로 소셜 로그인을 합니다.
+ *          tags: [Auth]
+ *          parameters:
+ *              - in: header
+ *                name: access_token
+ *                required: true
+ *                description: naver api에서 발급받은 access_token
+ *                schema:
+ *                    type: string
+ *              - in: header
+ *                name: refresh_token
+ *                required: true
+ *                description: naver api에서 발급받은 refresh_token
+ *                schema:
+ *                    type: string
+ *          responses:
+ *              200:
+ *                  description: spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하였을 경우 다음 결과가 반환됩니다. <br>
+ *                               응답의 header에 access_token과 refresh_token, platform을 담아 반환합니다.</br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                data:
+ *                                  type: object
+ *                                  properties:
+ *                                    user:
+ *                                      $ref: "#/components/schemas/UserToken"
+ *              400:
+ *                  description: |
+ *                    오류가 발생해 spoon feed에 네이버 계정으로 성공적으로 소셜 로그인하지 못했을 경우 다음 결과가 반환됩니다.</br>
+ *                    -오류 예시</br>
+ *                    - 만료되거나 올바르지않은 access_token이 요청 헤더에 들어온 경우<br>
+ *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                success: false
+ *                                error:
+ *                                  error: invalid_grant
+ *                                  error_description: expired_or_invalid_refresh_token
+ *                                  error_code: KOE322
+ *              401:
+ *                  description: Authentication Error |
+ *                    user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
+ *                    - 오류 예시</br>
+ *                    - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
+ *                  content:
+ *                      application/json:
+ *                          schema:
+ *                              type: object
+ *                              properties:
+ *                                success:
+ *                                  type: boolean
+ *                                error:
+ *                                  properties:
+ *                                   code:
+ *                                     type: string
+ *                                   message:
+ *                                     type: string
+ *                              example:
+ *                                success: false
+ *                                error:
+ *                                  code: -401
+ *                                  message: this access token does not exist
+ */

--- a/srcs/swagger/controller/auth.ts
+++ b/srcs/swagger/controller/auth.ts
@@ -347,6 +347,12 @@
  *                description: 발급받아 저장해뒀던 refresh_token
  *                schema:
  *                    type: string
+ *              - in: header
+ *                name: platform
+ *                required: true
+ *                description: 해당 user가 로그인했던 소셜 플랫폼(kaka, naver 중 하나)
+ *                schema:
+ *                    type: string
  *          responses:
  *              200:
  *                  description: access_token과 refresh_token을 성공적으로 갱신하였을 경우 다음 결과가 반환됩니다. <br>
@@ -382,7 +388,7 @@
  *                                  location: headers
  *              401:
  *                  description: |
- *                    인증 오류가 발생해 spoon feed에 kakao 계정으로 성공적으로 소셜 로그아웃하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                    인증 오류가 발생해 access_token과 refresh_token을 성공적으로 갱신하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                    -오류 예시</br>
  *                    - 만료되거나 올바르지않은 refresh_token이 요청 헤더에 들어온 경우<br>
  *                  content:

--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -516,3 +516,96 @@
  *                              code: authentication
  *                              message: The value of headers.access_token is not valid.
  */
+
+/**
+ * @swagger
+ * /user/{userId}/like/policy:
+ *  get:
+ *      description: 특정 user가 좋아요한 policy(정책)에 대한 데이터와 |
+ *                   해당 policy가 좋아요된 갯수를 반환합니다.
+ *      parameters:
+ *      - in: header
+ *        name: access_token
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 access_token
+ *      - in: header
+ *        name: platform
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 platform값
+ *      - in: path
+ *        name: userId
+ *        type: string
+ *        required: true
+ *        description: 특정 user의 userId값
+ *      tags: [User]
+ *      responses:
+ *          200:
+ *              description: 특정 user가 좋아요한 policy(정책)에 대한 데이터를 성공적으로 조회하였을 경우 다음 결과가 반환됩니다.(cnt는 해당 게시물에 달린 댓글의 갯수입니다.)
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            data:
+ *                              type: object
+ *                              properties:
+ *                                  policy:
+ *                                      type: array
+ *                                      items:
+ *                                          oneOf:
+ *                                          - $ref: "#/components/schemas/LikePolicy"
+ *                                          - $ref: "#/components/schemas/LikePolicy"
+ *          400:
+ *              description: |
+ *                오류가 발생해 특정 user가 좋아요한 policy(정책)에 대한 데이터를 성공적으로 조회하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - 존재하지 않는 userID가 들어온 경우 <br>
+ *                - No user in DB <br>
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: Error
+ *                              message: This userID does not exist.
+ *          401:
+ *              description: Authentication Error |
+ *                user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
+ *                - 만료되거나 올바르지 않은 형식의 access_token을 헤더에 넣어 보낸 경우 <br>
+ *                - platform값이 naver, kakao를 제외한 값인 경우
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: authentication
+ *                              message: The value of headers.access_token is not valid.
+ */

--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -28,6 +28,123 @@
 
 /**
  * @swagger
+ * /user:
+ *  patch:
+ *      description: 특정 user의 필터링값을 변경합니다.
+ *      parameters:
+ *      - in: header
+ *        name: access_token
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 access_token
+ *      - in: header
+ *        name: platform
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 platform값
+ *      tags: [User]
+ *      requestBody:
+ *        required: true
+ *        description: |
+ *          ### 변경할 상태 정보입니다.</br>
+ *          - id - nickname을 변경할 user의 id값입니다.</br>
+ *          - age - 변경될 age값입니다. `yyyymmdd`형식으로 입력합니다.</br>
+ *          - maritalStatus - 변경될 nickname값입니다.</br>
+ *          - workStatus - 변경될 workStatus값입니다.</br>
+ *          - companyScale - 변경될 companyScale값입니다.</br>
+ *          - medianIncome - 변경될 medianIncome값입니다.</br>
+ *          - annualIncome - 변경될 annualIncome값입니다.</br>
+ *          - asset - 변경될 asset값입니다.</br>
+ *          - isHouseOwner - 변경될 isHouseOwner값입니다.</br>
+ *          - hasHouse - 변경될 hasHouse값입니다.</br>
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                id:
+ *                  type: string
+ *                nickname:
+ *                  type: string
+ *              example:
+ *                "id": "7"
+ *                "age": "19960605"
+ *                "maritalStatus": "미혼"
+ *                "workStatus": "재직자"
+ *                "companyScale": "중소기업"
+ *                "medianIncome": "100% 이하"
+ *                "annualIncome": "외벌이 3.5천만원 이하"
+ *                "asset": "2.92억원 이하"
+ *                "isHouseOwner": "세대구성원"
+ *                "hasHouse": "무주택자"
+ *      responses:
+ *          200:
+ *              description: 특정 user를 필터링값을 성공적으로 변경했을 경우 다음 결과가 반환됩니다.
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            data:
+ *                              type: object
+ *                              properties:
+ *                                user:
+ *                                  $ref: "#/components/schemas/UserEntity"
+ *          400:
+ *              description: |
+ *                오류가 발생해 특정 user를 필터링값을 변경하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - 존재하지 않는 userID가 들어온 경우 <br>
+ *                - No user in DB <br>
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: Error
+ *                              message: This userID does not exist.
+ *          401:
+ *              description: Authentication Error |
+ *                user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
+ *                - 만료되거나 올바르지 않은 형식의 access_token을 헤더에 넣어 보낸 경우 <br>
+ *                - platform값이 naver, kakao를 제외한 값인 경우
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: authentication
+ *                              message: The value of headers.access_token is not valid.
+ */
+
+/**
+ * @swagger
  * /user/{userId}:
  *  get:
  *      description: 특정 user의 정보를 반환합니다.
@@ -50,7 +167,7 @@
  *      tags: [User]
  *      responses:
  *          200:
- *              description: 특정 user를 subject 랜덤 매칭 대기열에 성공적으로 추가하였을 경우 다음 결과가 반환됩니다.
+ *              description: 특정 user의 정보를 성공적으로 조회하였을 경우 다음 결과가 반환됩니다.
  *              content:
  *                  application/json:
  *                      schema:
@@ -65,7 +182,7 @@
  *                                  $ref: "#/components/schemas/UserEntity"
  *          400:
  *              description: |
- *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                오류가 발생해 특정 user의 정보를 성공적으로 조회하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
  *                - 존재하지 않는 userID가 들어온 경우 <br>
  *                - No user in DB <br>
@@ -151,7 +268,7 @@
  *                "nickname": "kiwi"
  *      responses:
  *          200:
- *              description: 특정 user를 subject 랜덤 매칭 대기열에 성공적으로 추가하였을 경우 다음 결과가 반환됩니다.
+ *              description: 특정 user의 nickname값을 성공적으로 변경하였을 경우 다음 결과가 반환됩니다.
  *              content:
  *                  application/json:
  *                      schema:
@@ -166,7 +283,7 @@
  *                                  $ref: "#/components/schemas/UserEntity"
  *          400:
  *              description: |
- *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                오류가 발생해 특정 user의 nickname값을 성공적으로 변경하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
  *                - 존재하지 않는 userID가 들어온 경우 <br>
  *                - No user in DB <br>
@@ -217,9 +334,9 @@
 
 /**
  * @swagger
- * /user:
- *  patch:
- *      description: 특정 user의 필터링값을 변경합니다.
+ * /user/{userId}/post:
+ *  get:
+ *      description: 특정 user가 작성한 모든 post(게시글)에 대한 데이터를 반환합니다.
  *      parameters:
  *      - in: header
  *        name: access_token
@@ -231,44 +348,15 @@
  *        type: string
  *        required: true
  *        description: 로그인하면서 발급받은 platform값
- *      tags: [User]
- *      requestBody:
+ *      - in: path
+ *        name: userId
+ *        type: string
  *        required: true
- *        description: |
- *          ### 변경할 상태 정보입니다.</br>
- *          - id - nickname을 변경할 user의 id값입니다.</br>
- *          - age - 변경될 age값입니다. `yyyymmdd`형식으로 입력합니다.</br>
- *          - maritalStatus - 변경될 nickname값입니다.</br>
- *          - workStatus - 변경될 workStatus값입니다.</br>
- *          - companyScale - 변경될 companyScale값입니다.</br>
- *          - medianIncome - 변경될 medianIncome값입니다.</br>
- *          - annualIncome - 변경될 annualIncome값입니다.</br>
- *          - asset - 변경될 asset값입니다.</br>
- *          - isHouseOwner - 변경될 isHouseOwner값입니다.</br>
- *          - hasHouse - 변경될 hasHouse값입니다.</br>
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                id:
- *                  type: string
- *                nickname:
- *                  type: string
- *              example:
- *                "id": "7"
- *                "age": "19960605"
- *                "maritalStatus": "미혼"
- *                "workStatus": "재직자"
- *                "companyScale": "중소기업"
- *                "medianIncome": "100% 이하"
- *                "annualIncome": "외벌이 3.5천만원 이하"
- *                "asset": "2.92억원 이하"
- *                "isHouseOwner": "세대구성원"
- *                "hasHouse": "무주택자"
+ *        description: 특정 user의 userId값
+ *      tags: [User]
  *      responses:
  *          200:
- *              description: 특정 user를 subject 랜덤 매칭 대기열에 성공적으로 추가하였을 경우 다음 결과가 반환됩니다.
+ *              description: 특정 user가 작성한 모든 post(게시글)에 대한 데이터를 성공적으로 조회하였을 경우 다음 결과가 반환됩니다.(cnt는 해당 게시물에 달린 댓글의 갯수입니다.)
  *              content:
  *                  application/json:
  *                      schema:
@@ -279,11 +367,15 @@
  *                            data:
  *                              type: object
  *                              properties:
- *                                user:
- *                                  $ref: "#/components/schemas/UserEntity"
+ *                                  post:
+ *                                      type: array
+ *                                      items:
+ *                                          oneOf:
+ *                                          - $ref: "#/components/schemas/PostArray"
+ *                                          - $ref: "#/components/schemas/PostArray"
  *          400:
  *              description: |
- *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                오류가 발생해 특정 user가 작성한 모든 post(게시글)에 대한 데이터를 성공적으로 조회하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
  *                - 존재하지 않는 userID가 들어온 경우 <br>
  *                - No user in DB <br>

--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -145,3 +145,139 @@
  *                              code: authentication
  *                              message: The value of headers.access_token is not valid.
  */
+
+/**
+ * @swagger
+ * /user/{userId}:
+ *  get:
+ *      description: get user same userId
+ *      tags: [User]
+ *      responses:
+ *          200:
+ *              description: success
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          $ref: "#/components/schemas/User"
+ *          400:
+ *              description: No user in DB
+ *          401:
+ *              description: Authentication Error
+ */
+
+/**
+ * @swagger
+ * /user:
+ *  patch:
+ *      description: 특정 user의 필터링값을 변경합니다.
+ *      parameters:
+ *      - in: header
+ *        name: access_token
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 access_token
+ *      - in: header
+ *        name: platform
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 platform값
+ *      tags: [User]
+ *      requestBody:
+ *        required: true
+ *        description: |
+ *          ### 변경할 상태 정보입니다.</br>
+ *          - id - nickname을 변경할 user의 id값입니다.</br>
+ *          - age - 변경될 age값입니다. `yyyymmdd`형식으로 입력합니다.</br>
+ *          - maritalStatus - 변경될 nickname값입니다.</br>
+ *          - workStatus - 변경될 workStatus값입니다.</br>
+ *          - companyScale - 변경될 companyScale값입니다.</br>
+ *          - medianIncome - 변경될 medianIncome값입니다.</br>
+ *          - annualIncome - 변경될 annualIncome값입니다.</br>
+ *          - asset - 변경될 asset값입니다.</br>
+ *          - isHouseOwner - 변경될 isHouseOwner값입니다.</br>
+ *          - hasHouse - 변경될 hasHouse값입니다.</br>
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                id:
+ *                  type: string
+ *                nickname:
+ *                  type: string
+ *              example:
+ *                "id": "7"
+ *                "age": "19960605"
+ *                "maritalStatus": "미혼"
+ *                "workStatus": "재직자"
+ *                "companyScale": "중소기업"
+ *                "medianIncome": "100% 이하"
+ *                "annualIncome": "외벌이 3.5천만원 이하"
+ *                "asset": "2.92억원 이하"
+ *                "isHouseOwner": "세대구성원"
+ *                "hasHouse": "무주택자"
+ *      responses:
+ *          200:
+ *              description: 특정 user를 subject 랜덤 매칭 대기열에 성공적으로 추가하였을 경우 다음 결과가 반환됩니다.
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            data:
+ *                              type: object
+ *                              properties:
+ *                                user:
+ *                                  $ref: "#/components/schemas/UserEntity"
+ *          400:
+ *              description: |
+ *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - 존재하지 않는 userID가 들어온 경우 <br>
+ *                - No user in DB <br>
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: Error
+ *                              message: This userID does not exist.
+ *          401:
+ *              description: Authentication Error |
+ *                user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
+ *                - 만료되거나 올바르지 않은 형식의 access_token을 헤더에 넣어 보낸 경우 <br>
+ *                - platform값이 naver, kakao를 제외한 값인 경우
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: authentication
+ *                              message: The value of headers.access_token is not valid.
+ */

--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -30,19 +30,88 @@
  * @swagger
  * /user/{userId}:
  *  get:
- *      description: get user same userId
+ *      description: 특정 user의 필터링값을 변경합니다.
+ *      parameters:
+ *      - in: header
+ *        name: access_token
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 access_token
+ *      - in: header
+ *        name: platform
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 platform값
+ *      - in: path
+ *        name: userId
+ *        type: string
+ *        required: true
+ *        description: 특정 user의 userId값
  *      tags: [User]
  *      responses:
  *          200:
- *              description: success
+ *              description: 특정 user를 subject 랜덤 매칭 대기열에 성공적으로 추가하였을 경우 다음 결과가 반환됩니다.
  *              content:
  *                  application/json:
  *                      schema:
- *                          $ref: "#/components/schemas/User"
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            data:
+ *                              type: object
+ *                              properties:
+ *                                user:
+ *                                  $ref: "#/components/schemas/UserEntity"
  *          400:
- *              description: No user in DB
+ *              description: |
+ *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - 존재하지 않는 userID가 들어온 경우 <br>
+ *                - No user in DB <br>
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: Error
+ *                              message: This userID does not exist.
  *          401:
- *              description: Authentication Error
+ *              description: Authentication Error |
+ *                user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
+ *                - 만료되거나 올바르지 않은 형식의 access_token을 헤더에 넣어 보낸 경우 <br>
+ *                - platform값이 naver, kakao를 제외한 값인 경우
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: authentication
+ *                              message: The value of headers.access_token is not valid.
  */
 
 /**
@@ -144,25 +213,6 @@
  *                            error:
  *                              code: authentication
  *                              message: The value of headers.access_token is not valid.
- */
-
-/**
- * @swagger
- * /user/{userId}:
- *  get:
- *      description: get user same userId
- *      tags: [User]
- *      responses:
- *          200:
- *              description: success
- *              content:
- *                  application/json:
- *                      schema:
- *                          $ref: "#/components/schemas/User"
- *          400:
- *              description: No user in DB
- *          401:
- *              description: Authentication Error
  */
 
 /**

--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -1,8 +1,16 @@
 /**
  * @swagger
+ * tags:
+ *   name: User
+ *   description: 유저
+ */
+
+/**
+ * @swagger
  * /user:
  *  get:
  *      description: get all users
+ *      tags: [User]
  *      responses:
  *          200:
  *              description: success
@@ -23,6 +31,7 @@
  * /user/{userId}:
  *  get:
  *      description: get user same userId
+ *      tags: [User]
  *      responses:
  *          200:
  *              description: success
@@ -34,4 +43,105 @@
  *              description: No user in DB
  *          401:
  *              description: Authentication Error
+ */
+
+/**
+ * @swagger
+ * /user/nickname:
+ *  patch:
+ *      description: 특정 user의 nickname값을 변경합니다.
+ *      parameters:
+ *      - in: header
+ *        name: access_token
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 access_token
+ *      - in: header
+ *        name: platform
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 platform값
+ *      tags: [User]
+ *      requestBody:
+ *        required: true
+ *        description: |
+ *          ### 변경할 상태 정보입니다.</br>
+ *          - id - nickname을 변경할 user의 id값입니다.</br>
+ *          - nickname - 변경될 nickname값입니다.</br>
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                id:
+ *                  type: string
+ *                nickname:
+ *                  type: string
+ *              example:
+ *                "id": "2"
+ *                "nickname": "kiwi"
+ *      responses:
+ *          200:
+ *              description: 특정 user를 subject 랜덤 매칭 대기열에 성공적으로 추가하였을 경우 다음 결과가 반환됩니다.
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            data:
+ *                              type: object
+ *                              properties:
+ *                                user:
+ *                                  $ref: "#/components/schemas/UserEntity"
+ *          400:
+ *              description: |
+ *                오류가 발생해 특정 user를 subject 랜덤 매칭 대기열에 추가하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - 존재하지 않는 userID가 들어온 경우 <br>
+ *                - No user in DB <br>
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: Error
+ *                              message: This userID does not exist.
+ *          401:
+ *              description: Authentication Error |
+ *                user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
+ *                - 만료되거나 올바르지 않은 형식의 access_token을 헤더에 넣어 보낸 경우 <br>
+ *                - platform값이 naver, kakao를 제외한 값인 경우
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: authentication
+ *                              message: The value of headers.access_token is not valid.
  */

--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -423,3 +423,96 @@
  *                              code: authentication
  *                              message: The value of headers.access_token is not valid.
  */
+
+/**
+ * @swagger
+ * /user/{userId}/comment:
+ *  get:
+ *      description: 특정 user가 작성한 모든 comment(댓글)에 대한 데이터와 |
+ *                   해당 comment가 작성된 post(게시글)의 title(제목), content(본문), createdAt(작성일)을 반환합니다.
+ *      parameters:
+ *      - in: header
+ *        name: access_token
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 access_token
+ *      - in: header
+ *        name: platform
+ *        type: string
+ *        required: true
+ *        description: 로그인하면서 발급받은 platform값
+ *      - in: path
+ *        name: userId
+ *        type: string
+ *        required: true
+ *        description: 특정 user의 userId값
+ *      tags: [User]
+ *      responses:
+ *          200:
+ *              description: 특정 user가 작성한 모든 comment(댓글)에 대한 데이터를 성공적으로 조회하였을 경우 다음 결과가 반환됩니다.(cnt는 해당 게시물에 달린 댓글의 갯수입니다.)
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            data:
+ *                              type: object
+ *                              properties:
+ *                                  comment:
+ *                                      type: array
+ *                                      items:
+ *                                          oneOf:
+ *                                          - $ref: "#/components/schemas/UserComment"
+ *                                          - $ref: "#/components/schemas/UserComment"
+ *          400:
+ *              description: |
+ *                오류가 발생해 특정 user가 작성한 모든 comment(댓글)에 대한 데이터를 성공적으로 조회하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - 존재하지 않는 userID가 들어온 경우 <br>
+ *                - No user in DB <br>
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: Error
+ *                              message: This userID does not exist.
+ *          401:
+ *              description: Authentication Error |
+ *                user인증에 실패했을 경우 해당 오류가 반환됩니다.</br></br>
+ *                -오류 예시</br>
+ *                - access_token or platform을 헤더값에 넣지 않고 요청을 보낸경우 <br>
+ *                - 만료되거나 올바르지 않은 형식의 access_token을 헤더에 넣어 보낸 경우 <br>
+ *                - platform값이 naver, kakao를 제외한 값인 경우
+ *              content:
+ *                  application/json:
+ *                      schema:
+ *                          type: object
+ *                          properties:
+ *                            success:
+ *                              type: boolean
+ *                            error:
+ *                              properties:
+ *                               code:
+ *                                 type: string
+ *                               message:
+ *                                 type: string
+ *                          example:
+ *                            success: false
+ *                            error:
+ *                              code: authentication
+ *                              message: The value of headers.access_token is not valid.
+ */

--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -30,7 +30,7 @@
  * @swagger
  * /user/{userId}:
  *  get:
- *      description: 특정 user의 필터링값을 변경합니다.
+ *      description: 특정 user의 정보를 반환합니다.
  *      parameters:
  *      - in: header
  *        name: access_token

--- a/srcs/swagger/schema/comment.ts
+++ b/srcs/swagger/schema/comment.ts
@@ -10,3 +10,24 @@
  *                  content:
  *                      type: string
  */
+
+/**
+ * @swagger
+ *  components:
+ *      schemas:
+ *          UserComment:
+ *              type: object
+ *              properties:
+ *                  user_id:
+ *                      type: number
+ *                  post_id:
+ *                      type: number
+ *                  comment_id:
+ *                      type: number
+ *                  title:
+ *                      type: string
+ *                  content:
+ *                      type: string
+ *                  createdAt:
+ *                      type: string
+ */

--- a/srcs/swagger/schema/policy.ts
+++ b/srcs/swagger/schema/policy.ts
@@ -75,3 +75,26 @@
  *                  likeCount:
  *                      type: string
  */
+
+/**
+ * @swagger
+ *  components:
+ *      schemas:
+ *          LikePolicy:
+ *              type: object
+ *              properties:
+ *                  user_id:
+ *                      type: number
+ *                  policy_id:
+ *                      type: number
+ *                  category:
+ *                      type: string
+ *                  name:
+ *                      type: string
+ *                  content:
+ *                      type: string
+ *                  application_period:
+ *                      type: string
+ *                  cnt:
+ *                      type: number
+ */

--- a/srcs/swagger/schema/post.ts
+++ b/srcs/swagger/schema/post.ts
@@ -37,3 +37,28 @@
  *                  comments:
  *                      type: string
  */
+
+/**
+ * @swagger
+ *  components:
+ *      schemas:
+ *          PostArray:
+ *              type: object
+ *              properties:
+ *                  user_id:
+ *                      type: number
+ *                  post_id:
+ *                      type: number
+ *                  category:
+ *                      type: string
+ *                  title:
+ *                      type: string
+ *                  content:
+ *                      type: string
+ *                  cnt:
+ *                      type: number
+ *                  createdAt:
+ *                      type: string
+ *                  updatedAt:
+ *                      type: string
+ */

--- a/srcs/swagger/schema/user.ts
+++ b/srcs/swagger/schema/user.ts
@@ -78,34 +78,3 @@
  *                  updatedAt:
  *                      type: string
  */
-
-/**
- * @swagger
- *  components:
- *      schemas:
- *          Filter:
- *              type: object
- *              properties:
- *                  category:
- *                      type: string
- *                  id:
- *                      type: number
- *                  age:
- *                      type: string
- *                  maritalStatus:
- *                      type: string
- *                  workStatus:
- *                      type: string
- *                  companyScale:
- *                      type: string
- *                  medianIncome:
- *                      type: string
- *                  annualIncome:
- *                      type: string
- *                  asset:
- *                      type: string
- *                  isHouseOwner:
- *                      type: string
- *                  hasHouse:
- *                      type: string
- */

--- a/srcs/swagger/schema/user.ts
+++ b/srcs/swagger/schema/user.ts
@@ -78,3 +78,49 @@
  *                  updatedAt:
  *                      type: string
  */
+
+/**
+ * @swagger
+ *  components:
+ *      schemas:
+ *          UserToken:
+ *              type: object
+ *              properties:
+ *                  id:
+ *                      type: number
+ *                  nickname:
+ *                      type: string
+ *                  age:
+ *                      type: string
+ *                  workStatus:
+ *                      type: string
+ *                  companyScale:
+ *                      type: string
+ *                  medianIncome:
+ *                      type: string
+ *                  annualIncome:
+ *                      type: string
+ *                  asset:
+ *                      type: string
+ *                  hasHouse:
+ *                      type: string
+ *                  isHouseOwner:
+ *                      type: string
+ *                  maritalStatus:
+ *                      type: string
+ *                  email:
+ *                      type: string
+ *                  createdAt:
+ *                      type: string
+ *                  updatedAt:
+ *                      type: string
+ *                  token:
+ *                      type: object
+ *                      properties:
+ *                          id:
+ *                              type : number
+ *                          refreshToken:
+ *                              type : string
+ *                          createdAt:
+ *                              type : string
+ */

--- a/srcs/swagger/schema/user.ts
+++ b/srcs/swagger/schema/user.ts
@@ -41,3 +41,71 @@
  *                  hasHouse:
  *                      type: string
  */
+
+/**
+ * @swagger
+ *  components:
+ *      schemas:
+ *          UserEntity:
+ *              type: object
+ *              properties:
+ *                  id:
+ *                      type: number
+ *                  nickname:
+ *                      type: string
+ *                  age:
+ *                      type: string
+ *                  workStatus:
+ *                      type: string
+ *                  companyScale:
+ *                      type: string
+ *                  medianIncome:
+ *                      type: string
+ *                  annualIncome:
+ *                      type: string
+ *                  asset:
+ *                      type: string
+ *                  hasHouse:
+ *                      type: string
+ *                  isHouseOwner:
+ *                      type: string
+ *                  maritalStatus:
+ *                      type: string
+ *                  email:
+ *                      type: string
+ *                  createdAt:
+ *                      type: string
+ *                  updatedAt:
+ *                      type: string
+ */
+
+/**
+ * @swagger
+ *  components:
+ *      schemas:
+ *          Filter:
+ *              type: object
+ *              properties:
+ *                  category:
+ *                      type: string
+ *                  id:
+ *                      type: number
+ *                  age:
+ *                      type: string
+ *                  maritalStatus:
+ *                      type: string
+ *                  workStatus:
+ *                      type: string
+ *                  companyScale:
+ *                      type: string
+ *                  medianIncome:
+ *                      type: string
+ *                  annualIncome:
+ *                      type: string
+ *                  asset:
+ *                      type: string
+ *                  isHouseOwner:
+ *                      type: string
+ *                  hasHouse:
+ *                      type: string
+ */


### PR DESCRIPTION
resolved: #53 

아래 api들에 대해서 swagger api 문서 작성
- 네이버 소셜 로그인 api
- 카카오 소셜 로그인 api
- 네이버 소셜 로그아웃 api
- 카카오 소셜 로그아웃 api
- 액세스 토큰 갱신 api
- 온보딩 - user의 nickname 변경 api
- user필터링 데이터 변경 api
- user정보 조회 api
- 특정 user가 작성한 post들의 정보를 반환하는 api
- 특정 user가 작성한 댓글들과 그 댓글이 달린 post의 정보를 반환하는 api
- 특정 user가 찜한 정책들의 정보를 반환하는 api