### PR TITLE
docs: swagger api 문서 수정

### DIFF
--- a/srcs/swagger/controller/getUser.ts
+++ b/srcs/swagger/controller/getUser.ts
@@ -286,7 +286,7 @@
  *                오류가 발생해 특정 user의 nickname값을 성공적으로 변경하지 못했을 경우 다음 결과가 반환됩니다.</br></br>
  *                -오류 예시</br>
  *                - 존재하지 않는 userID가 들어온 경우 <br>
- *                - No user in DB <br>
+ *                - requestBody.id값이 숫자형 문자열이 아닌경우 ex) '1', '2' <br>
  *              content:
  *                  application/json:
  *                      schema:

--- a/srcs/swagger/schema/policy.ts
+++ b/srcs/swagger/schema/policy.ts
@@ -112,6 +112,8 @@
  *                      type: string
  *                  name:
  *                      type: string
+ *                  host:
+ *                      type: string
  *                  content:
  *                      type: string
  *                  application_period:


### PR DESCRIPTION
- GET /user/:id/like/policy api 문서 200번대 응답의 예시 스키마에 host 키값 추가
- patch /user/nickname api의 400번대 오류 설명 수정

resolved: #89 