### PR TITLE
fix: front-end 파트 요청으로 로그인, 유저 차단 api 수정

### DIFF
--- a/srcs/controllers/controller.signinKakao.ts
+++ b/srcs/controllers/controller.signinKakao.ts
@@ -62,6 +62,8 @@ const signinKakao: RequestHandler = async (req, res) => {
             await updateTokenById(dbUser.token.id, refreshToken);
             newUser = dbUser;
         }
+        userObj.email = newUser.email;
+        newUser = (await findOneUserByEmail(userObj)) as User;
 
         newUser = await toResObj(newUser);
         // user 데이터를 반환합니다.

--- a/srcs/controllers/controller.signinNaver.ts
+++ b/srcs/controllers/controller.signinNaver.ts
@@ -52,6 +52,9 @@ const signinNaver: RequestHandler = async (req, res) => {
             await updateTokenById(dbUser.token.id, refreshToken);
             newUser = dbUser;
         }
+        userObj.email = newUser.email;
+        newUser = (await findOneUserByEmail(userObj)) as User;
+
         // user 데이터를 반환합니다.
         newUser = await toResObj(newUser);
         return res

--- a/srcs/controllers/controller.signoutNaver.ts
+++ b/srcs/controllers/controller.signoutNaver.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 import { findOneUserByEmail, updateToken } from '../repository/index';
-import { getNaverAccessTokenInfo, logoutNaver } from '../lib/index';
+import { getNaverAccessTokenInfo } from '../lib/index';
 import { tUser } from '../../@types/types';
 
 const signoutNaver: RequestHandler = async (req, res, next) => {
@@ -22,13 +22,13 @@ const signoutNaver: RequestHandler = async (req, res, next) => {
         }
 
         const email = tokenInfo.data.response.email as string;
-        const logoutResponse = await logoutNaver(accessToken);
-        if (logoutResponse.status !== 200) {
-            return res.status(401).json({
-                success: false,
-                error: logoutResponse.data,
-            });
-        }
+        // const logoutResponse = await logoutNaver(accessToken);
+        // if (logoutResponse.status !== 200) {
+        //     return res.status(401).json({
+        //         success: false,
+        //         error: logoutResponse.data,
+        //     });
+        // }
         const userObj: tUser = {
             email,
         };

--- a/srcs/repository/repository.posts.ts
+++ b/srcs/repository/repository.posts.ts
@@ -19,7 +19,6 @@ const findAllPosts: (userId: string) => Promise<Post[]> = async (userId) => {
     let blocked_user: any[] | string = await findOneUserBlock(userId);
     blocked_user = blocked_user.map((e) => e.blocked_id);
     if (blocked_user.length === 0) blocked_user = '';
-    console.log(blocked_user);
 
     const result = await Post.createQueryBuilder('post')
         .select(['id', 'author', 'title', 'category', 'content', 'commentCount'])

--- a/srcs/repository/repository.posts.ts
+++ b/srcs/repository/repository.posts.ts
@@ -18,7 +18,8 @@ import {
 const findAllPosts: (userId: string) => Promise<Post[]> = async (userId) => {
     let blocked_user: any[] | string = await findOneUserBlock(userId);
     blocked_user = blocked_user.map((e) => e.blocked_id);
-    if (!blocked_user) blocked_user = '';
+    if (blocked_user.length === 0) blocked_user = '';
+    console.log(blocked_user);
 
     const result = await Post.createQueryBuilder('post')
         .select(['id', 'author', 'title', 'category', 'content', 'commentCount'])
@@ -115,7 +116,7 @@ const findCommentsByPostId: (
 ) => Promise<Comment[] | undefined> = async (postId, userId) => {
     let blocked_user: any[] | string = await findOneUserBlock(userId);
     blocked_user = blocked_user.map((e) => e.blocked_id);
-    if (!blocked_user) blocked_user = '';
+    if (blocked_user.length === 0) blocked_user = '';
 
     const result = await Comment.createQueryBuilder('comment')
         .select(['id', 'content', 'commenter'])
@@ -206,7 +207,7 @@ const findPostsByKeyword: (query: string, userId: string) => Promise<Post[] | un
 ) => {
     let blocked_user: any[] | string = await findOneUserBlock(userId);
     blocked_user = blocked_user.map((e) => e.blocked_id);
-    if (!blocked_user) blocked_user = '';
+    if (blocked_user.length === 0) blocked_user = '';
 
     const result = await await Post.createQueryBuilder('post')
         .select(['id', 'author', 'title', 'category', 'content', 'commentCount'])


### PR DESCRIPTION
- 로그인 api에서 body에 최신화된 user데이터 반환
- 네이버 로그아웃에서 연동해제 로직 없애기
- 차단한 유저가 없는 경우 유저 조회 로직 에러 수정

resolved: #150